### PR TITLE
Add email signup, cleanup, duplicate at bottom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # DistrictBuilder Public Roadmap
 In this repository, you can find the [official DistrictBuilder public product roadmap](https://github.com/PublicMapping/db-roadmap/projects/1). Our product roadmap is where you can learn about what features we're working on, what stage they're in, and when we expect to bring them to you. Have any questions or comments about items on the roadmap? Email us at support@districtbuilder.org.
 
-:eight_spoked_asterisk: [**Click here to go to the roadmap**](https://github.com/PublicMapping/db-roadmap/projects/1)
+:eight_spoked_asterisk: &nbsp; [**Go to the product roadmap**](https://github.com/PublicMapping/db-roadmap/projects/1)
+
+:envelope: &nbsp; [Sign up for email updates](https://districtbuilder.us1.list-manage.com/subscribe?u=61da999c9897859f1c1fff262&id=70fdf1ae35) to hear when we launch new features
 
 ## Guide to the roadmap
 
@@ -35,3 +37,9 @@ Each issue is labeled with the stage of development the feature is in. Each feat
 ## Disclaimer 
 
 Any statement in this repository that is not purely historical is considered a forward-looking statement. Forward-looking statements included in this repository are based on information available to the Public Mapping Project as of the date they are made, and the Public Mapping Projects assumes no obligation to update any forward-looking statements. The forward-looking product roadmap does not represent a commitment, guarantee, obligation or promise to deliver any product or feature, or to deliver any product and feature by any particular date, and is intended to outline the general development plans. Customers should not rely on this roadmap to make any purchasing decision.
+
+---
+
+:eight_spoked_asterisk: &nbsp; [**Go to the product roadmap**](https://github.com/PublicMapping/db-roadmap/projects/1)
+
+:envelope: &nbsp; [Sign up for email updates](https://districtbuilder.us1.list-manage.com/subscribe?u=61da999c9897859f1c1fff262&id=70fdf1ae35) to hear when we launch new features


### PR DESCRIPTION
I thought it could be useful to promote email signup here, for users who want to be the first to hear about new features as we progress through the road map. I added a space between the icons and the text. 

I also duplicated the roadmap and email updates at the bottom of the page, in case the user scrolls to the bottom and hasn't found them. That's a little bit weird, but I'm slightly concerned that users will miss those links, or land on this page and think this page is the roadmap and not realize they need to go to a new page. I actually felt confused when I first landed here. Not sure if this is the ideal solution, but could be good for now.